### PR TITLE
Make wayspots marked as 'Not in Pogo' deletable if they were removed from the map; renaming to 'wayspots'

### DIFF
--- a/s2check.user.js
+++ b/s2check.user.js
@@ -6,7 +6,7 @@
 // @downloadURL  https://raw.githubusercontent.com/PoGOHWH/iitc-ce-pogo-s2/pogohwh/s2check.user.js
 // @homepageURL  https://github.com/PoGOHWH/iitc-ce-pogo-s2
 // @supportURL   https://twitter.com/PogoCells
-// @version      0.99.0
+// @version      0.99.1
 // @description  Pokemon Go tools over IITC. News on https://twitter.com/PogoCells
 // @author       Alfonso M.
 // @match        https://intel.ingress.com/*
@@ -898,7 +898,7 @@
 			classifyGroup(cells, gyms, level, (cell, item) => cell.gyms.push(item));
 			classifyGroup(cells, pokestops, level, (cell, item) => cell.stops.push(item));
 			classifyGroup(cells, newPortals, level, (cell, item) => cell.notClassified.push(item));
-			classifyGroup(cells, notpogo, level, (cell, item) => {/* */});
+			classifyGroup(cells, notpogo, level, (cell, item) => cell.notpogo.push(item));
 
 			return cells;
 		}
@@ -926,7 +926,8 @@
 						cell: cell,
 						gyms: [],
 						stops: [],
-						notClassified: []
+						notClassified: [],
+						notpogo: []
 					};
 				}
 				callback(cells[cellId], item);
@@ -2750,7 +2751,7 @@
 				const data = allCells[id];
 				checkIsPortalMissing(data.gyms, data);
 				checkIsPortalMissing(data.stops, data);
-				//checkIsPortalMissing(data.notpogo);
+				checkIsPortalMissing(data.notpogo, data);
 
 				if (data.notClassified.length == 0)
 					return;
@@ -3155,7 +3156,7 @@
 				id: 'missingPortals',
 				html: div,
 				width: width + 'px',
-				title: 'These portals are missing in Ingress',
+				title: 'These wayspots are no longer available',
 				buttons: {
 				}
 			});
@@ -3687,10 +3688,10 @@
 				document.getElementById('sidebar').appendChild(sidebarPogo);
 			}
 
-			sidebarPogo.appendChild(createCounter('New pokestops', 'pokestops', promptForNewPokestops));
+			sidebarPogo.appendChild(createCounter('New wayspots', 'pokestops', promptForNewPokestops));
 			sidebarPogo.appendChild(createCounter('Review required', 'classification', promptToClassifyPokestops));
-			sidebarPogo.appendChild(createCounter('Moved portals', 'moved', promptToMovePokestops));
-			sidebarPogo.appendChild(createCounter('Missing portals', 'missing', promptToRemovePokestops));
+			sidebarPogo.appendChild(createCounter('Moved wayspots', 'moved', promptToMovePokestops));
+			sidebarPogo.appendChild(createCounter('Missing wayspots', 'missing', promptToRemovePokestops));
 			sidebarPogo.appendChild(createCounter('New Gyms', 'gyms', promptToClassifyGyms));
 			sidebarPogo.appendChild(createCounter('Cells with extra Gyms', 'extraGyms', promptToVerifyGyms));
 

--- a/s2check.user.js
+++ b/s2check.user.js
@@ -6,7 +6,7 @@
 // @downloadURL  https://raw.githubusercontent.com/PoGOHWH/iitc-ce-pogo-s2/pogohwh/s2check.user.js
 // @homepageURL  https://github.com/PoGOHWH/iitc-ce-pogo-s2
 // @supportURL   https://twitter.com/PogoCells
-// @version      0.98.0
+// @version      0.98.1
 // @description  Pokemon Go tools over IITC. News on https://twitter.com/PogoCells
 // @author       Alfonso M.
 // @match        https://intel.ingress.com/*
@@ -2128,7 +2128,7 @@
 					opacity: settings.colors.notpogoOuter.opacity,
 					fillColor: settings.colors.notpogoInner.color,
 					fillOpacity: settings.colors.notpogoInner.opacity,
-					pane: 'pogoPaneStops'
+					pane: 'pogoPaneNotinpogo'
 				});
 			}
 
@@ -3638,6 +3638,7 @@
 			loadSettings();
 
 			// NOTE: PoGOHWH Edition: Create panes just for our markers
+			map.createPane('pogoPaneNotinpogo');
 			map.createPane('pogoPaneStops');
 			map.createPane('pogoPaneGyms');
 

--- a/s2check.user.js
+++ b/s2check.user.js
@@ -2546,8 +2546,16 @@
 	}
 
 	/* NOTE: PoGOHWH Edition: Our custom Pane needs a particular Z-index */
-	.leaflet-pogoStops-pane, .leaflet-pogoGyms-pane {
+	.leaflet-pogoNotinpogo-pane {
 		z-index: 450;
+		pointer-events: none;
+	}
+	.leaflet-pogoStops-pane {
+		z-index: 451;
+		pointer-events: none;
+	}
+	.leaflet-pogoGyms-pane {
+		z-index: 452;
 		pointer-events: none;
 	}
 

--- a/s2check.user.js
+++ b/s2check.user.js
@@ -6,7 +6,7 @@
 // @downloadURL  https://raw.githubusercontent.com/PoGOHWH/iitc-ce-pogo-s2/pogohwh/s2check.user.js
 // @homepageURL  https://github.com/PoGOHWH/iitc-ce-pogo-s2
 // @supportURL   https://twitter.com/PogoCells
-// @version      0.98.1
+// @version      0.99.0
 // @description  Pokemon Go tools over IITC. News on https://twitter.com/PogoCells
 // @author       Alfonso M.
 // @match        https://intel.ingress.com/*
@@ -755,6 +755,14 @@
 			data.portal.setStyle(hidePortalOwnershipStyles);
 		}
 
+		function changeLocationCircle() {
+			if (window.plugin.userLocation && window.plugin.userLocation.circle) {
+				var newRadius = settings.thisIsPogo ? 80 : 40;
+				window.plugin.userLocation.circle.setRadius(newRadius);
+				window.plugin.userLocation.onZoomEnd();
+			}
+		}
+
 		function setThisIsPogo() {
 			document.body.classList[settings.thisIsPogo ? 'add' : 'remove']('thisIsPogo');
 			// It seems that iOS has some bug in the following code, but I can't debug it.
@@ -764,6 +772,7 @@
 			try {
 				if (settings.thisIsPogo) {
 					removeIngressLayers();
+					changeLocationCircle();
 					if (chat && chat.requestPublic) {
 						originalChatRequestPublic = chat && chat.requestPublic;
 						chat.requestPublic = function () {}; // no requests for chat
@@ -791,6 +800,7 @@
 
 				} else {
 					restoreIngressLayers();
+					changeLocationCircle();
 					if (originalChatRequestPublic) {
 						chat.requestPublic = originalChatRequestPublic;
 						originalChatRequestPublic = null;
@@ -821,7 +831,7 @@
 					}
 				}
 			} catch (e) {
-				alert('Error initializing ThisIsPogo');
+				alert('Error initializing ThisIsPogo: ' + e);
 				console.log(e); // eslint-disable-line no-console
 			}
 		}
@@ -3642,6 +3652,8 @@
 
 			initSvgIcon();
 			window.addPortalHighlighter(highlighterTitle, markPortalsAsNeutral);
+
+			window.addHook('pluginUserLocation', changeLocationCircle);
 
 			loadSettings();
 


### PR DESCRIPTION
A small fix for wayspots marked with "Not in Pogo".

@5310 I couldn't push directly, that's why I created another PR :)